### PR TITLE
Add Application create/delete for controlling access to the API

### DIFF
--- a/lib/companion/companion_web/application.ex
+++ b/lib/companion/companion_web/application.ex
@@ -1,0 +1,22 @@
+defmodule Companion.CompanionWeb.Application do
+  @moduledoc """
+  Schema for Applications, which controls access to the API
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "applications" do
+    field(:name, :string)
+    field(:token, Ecto.UUID)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(application, attrs) do
+    application
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> put_change(:token, Ecto.UUID.generate())
+  end
+end

--- a/lib/companion/companion_web/companion_web.ex
+++ b/lib/companion/companion_web/companion_web.ex
@@ -1,0 +1,104 @@
+defmodule Companion.CompanionWeb do
+  @moduledoc """
+  The CompanionWeb context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Companion.Repo
+
+  alias Companion.CompanionWeb.Application
+
+  @doc """
+  Returns the list of applications.
+
+  ## Examples
+
+      iex> list_applications()
+      [%Application{}, ...]
+
+  """
+  def list_applications do
+    Repo.all(Application)
+  end
+
+  @doc """
+  Gets a single application.
+
+  Raises `Ecto.NoResultsError` if the Application does not exist.
+
+  ## Examples
+
+      iex> get_application!(123)
+      %Application{}
+
+      iex> get_application!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_application!(id), do: Repo.get!(Application, id)
+
+  @doc """
+  Creates a application.
+
+  ## Examples
+
+      iex> create_application(%{name: "example"})
+      {:ok, %Application{}}
+
+      iex> create_application(%{})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_application(attrs \\ %{}) do
+    %Application{}
+    |> Application.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a application.
+
+  ## Examples
+
+      iex> update_application(application, %{name: "new name"})
+      {:ok, %Application{}}
+
+      iex> update_application(application, %{})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_application(%Application{} = application, attrs) do
+    application
+    |> Application.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Application.
+
+  ## Examples
+
+      iex> delete_application(application)
+      {:ok, %Application{}}
+
+      iex> delete_application(application)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_application(%Application{} = application) do
+    Repo.delete(application)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking application changes.
+
+  ## Examples
+
+      iex> change_application(%Application{})
+      %Ecto.Changeset{source: %Application{}}
+
+  """
+  def change_application(%Application{} = application) do
+    Application.changeset(application, %{})
+  end
+end

--- a/lib/companion/companion_web/companion_web.ex
+++ b/lib/companion/companion_web/companion_web.ex
@@ -57,7 +57,7 @@ defmodule Companion.CompanionWeb do
   end
 
   @doc """
-  Creates a application.
+  Creates an application.
 
   ## Examples
 
@@ -75,7 +75,7 @@ defmodule Companion.CompanionWeb do
   end
 
   @doc """
-  Updates a application.
+  Updates an application.
 
   ## Examples
 
@@ -93,7 +93,7 @@ defmodule Companion.CompanionWeb do
   end
 
   @doc """
-  Deletes a Application.
+  Deletes an Application.
 
   ## Examples
 

--- a/lib/companion/companion_web/companion_web.ex
+++ b/lib/companion/companion_web/companion_web.ex
@@ -38,6 +38,25 @@ defmodule Companion.CompanionWeb do
   def get_application!(id), do: Repo.get!(Application, id)
 
   @doc """
+  Gets an application by the token.
+
+  ## Examples
+
+      iex> get_application_by_token("example-token")
+      %Application{}
+
+      iex> get_application_by_token("bad-token")
+      nil
+
+  """
+  def get_application_by_token(token) do
+    case Ecto.UUID.cast(token) do
+      {:ok, token} -> Repo.get_by(Application, token: token)
+      :error -> nil
+    end
+  end
+
+  @doc """
   Creates a application.
 
   ## Examples

--- a/lib/companion_web/controllers/apiroot_controller.ex
+++ b/lib/companion_web/controllers/apiroot_controller.ex
@@ -1,0 +1,7 @@
+defmodule CompanionWeb.ApiRootController do
+  use CompanionWeb, :controller
+
+  def index(conn, _params) do
+    json(conn, %{})
+  end
+end

--- a/lib/companion_web/controllers/application_controller.ex
+++ b/lib/companion_web/controllers/application_controller.ex
@@ -1,0 +1,34 @@
+defmodule CompanionWeb.ApplicationController do
+  use CompanionWeb, :controller
+
+  alias Companion.CompanionWeb
+  alias Companion.CompanionWeb.Application
+
+  def index(conn, _params) do
+    applications = CompanionWeb.list_applications()
+    changeset = CompanionWeb.change_application(%Application{})
+    render(conn, "index.html", applications: applications, changeset: changeset)
+  end
+
+  def create(conn, %{"application" => application_params}) do
+    case CompanionWeb.create_application(application_params) do
+      {:ok, _application} ->
+        conn
+        |> put_flash(:info, "Application created successfully.")
+        |> redirect(to: application_path(conn, :index))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        applications = CompanionWeb.list_applications()
+        render(conn, "index.html", applications: applications, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    application = CompanionWeb.get_application!(id)
+    {:ok, _application} = CompanionWeb.delete_application(application)
+
+    conn
+    |> put_flash(:info, "Application deleted successfully.")
+    |> redirect(to: application_path(conn, :index))
+  end
+end

--- a/lib/companion_web/controllers/page_controller.ex
+++ b/lib/companion_web/controllers/page_controller.ex
@@ -1,7 +1,0 @@
-defmodule CompanionWeb.PageController do
-  use CompanionWeb, :controller
-
-  def index(conn, _params) do
-    render(conn, "index.html", user: get_session(conn, :user))
-  end
-end

--- a/lib/companion_web/plugs/auth_plugs.ex
+++ b/lib/companion_web/plugs/auth_plugs.ex
@@ -35,3 +35,67 @@ defmodule CompanionWeb.Plugs.ExtractUserFromSession do
     assign(conn, :user, get_session(conn, :user))
   end
 end
+
+defmodule CompanionWeb.Plugs.ExtractApplicationFromHeader do
+  @moduledoc """
+  Extracts the token from the headers and looks up the application for the token and assigns it
+  to `application`.
+  """
+  import Plug.Conn
+  import Companion.CompanionWeb
+
+  def init(default), do: default
+
+  def call(%{assigns: %{application: _application}} = conn, _) do
+    # If there's already a user, then don't overwrite
+    conn
+  end
+
+  def call(conn, _) do
+    application =
+      conn
+      |> get_req_header("authorization")
+      |> fetch_token_from_header
+      |> get_application
+
+    assign(conn, :application, application)
+  end
+
+  defp fetch_token_from_header([]) do
+    :no_token
+  end
+
+  defp fetch_token_from_header([token | _]) do
+    case String.split(token) do
+      ["Token", value] -> value
+      _ -> :no_token
+    end
+  end
+
+  defp get_application(:no_token) do
+    nil
+  end
+
+  defp get_application(token) do
+    get_application_by_token(token)
+  end
+end
+
+defmodule CompanionWeb.Plugs.RequireApplication do
+  @moduledoc """
+  A plug that if there's no `application` in the session, returns a 401 Unauthorized
+  """
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(%{assigns: %{application: nil}} = conn, _) do
+    conn
+    |> send_resp(:unauthorized, "")
+    |> halt
+  end
+
+  def call(%{assigns: %{application: _application}} = conn, _) do
+    conn
+  end
+end

--- a/lib/companion_web/router.ex
+++ b/lib/companion_web/router.ex
@@ -18,12 +18,17 @@ defmodule CompanionWeb.Router do
     plug CompanionWeb.Plugs.RequireLoggedIn, "/auth/login"
   end
 
+  pipeline :authenticated do
+    plug CompanionWeb.Plugs.ExtractApplicationFromHeader
+    plug CompanionWeb.Plugs.RequireApplication
+  end
+
   scope "/", CompanionWeb do
     # Use the default browser stack
     pipe_through [:browser, :logged_in]
 
     get "/", ApplicationController, :index
-    resources "/applications", ApplicationController
+    resources "/applications", ApplicationController, only: [:create, :delete]
   end
 
   scope "/auth", CompanionWeb do
@@ -33,5 +38,11 @@ defmodule CompanionWeb.Router do
     get "/logout", AuthController, :logout
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
+  end
+
+  scope "/api/v1", CompanionWeb do
+    pipe_through [:api, :authenticated]
+
+    get "/", ApiRootController, :index
   end
 end

--- a/lib/companion_web/router.ex
+++ b/lib/companion_web/router.ex
@@ -22,7 +22,8 @@ defmodule CompanionWeb.Router do
     # Use the default browser stack
     pipe_through [:browser, :logged_in]
 
-    get "/", PageController, :index
+    get "/", ApplicationController, :index
+    resources "/applications", ApplicationController
   end
 
   scope "/auth", CompanionWeb do

--- a/lib/companion_web/templates/application/form.html.eex
+++ b/lib/companion_web/templates/application/form.html.eex
@@ -1,0 +1,11 @@
+<%= form_for @changeset, @action, fn f -> %>
+<div class="form-inline">
+  <div class="form-group mx-sm-3">
+    <%= label f, :name, class: "sr-only" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <%= submit "Create", class: "btn btn-primary" %>
+</div>
+<% end %>

--- a/lib/companion_web/templates/application/index.html.eex
+++ b/lib/companion_web/templates/application/index.html.eex
@@ -1,0 +1,24 @@
+<%= render "form.html", Map.put(assigns, :action, application_path(@conn, :create)) %>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Token</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for application <- @applications do %>
+    <tr>
+      <td><%= application.name %></td>
+      <td><%= application.token %></td>
+
+      <td class="text-right">
+        <span><%= link "Delete", to: application_path(@conn, :delete, application), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>

--- a/lib/companion_web/templates/layout/app.html.eex
+++ b/lib/companion_web/templates/layout/app.html.eex
@@ -21,14 +21,11 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
             <div class="navbar-nav mr-auto">
-              <a class="nav-item nav-link" href="/">Home <span class="sr-only">(current)</span></a>
-              <a class="nav-item nav-link" href="#">Item 1</a>
-              <a class="nav-item nav-link" href="#">Item 2</a>
-              <a class="nav-item nav-link" href="#">Item 3</a>
+              <a class="nav-item nav-link <%= if @conn.request_path == application_path @conn, :index do %>active<% end %>" href="<%= application_path @conn, :index %>">Applications</a>
             </div>
             <%= if @user do %>
             <div class="navbar-nav ml-auto">
-              <a class="nav-item nav-link" href="/auth/logout">Logout</a>
+              <a class="nav-item nav-link" href="<%= auth_path @conn, :logout %>">Logout</a>
             </div>
             <% end %>
           </div>

--- a/lib/companion_web/templates/page/index.html.eex
+++ b/lib/companion_web/templates/page/index.html.eex
@@ -1,1 +1,0 @@
-<h1 class="center">Welcome to the NurseConnect Companion</h1>

--- a/lib/companion_web/views/application_view.ex
+++ b/lib/companion_web/views/application_view.ex
@@ -1,0 +1,3 @@
+defmodule CompanionWeb.ApplicationView do
+  use CompanionWeb, :view
+end

--- a/priv/repo/migrations/20180611140220_create_applications.exs
+++ b/priv/repo/migrations/20180611140220_create_applications.exs
@@ -1,0 +1,13 @@
+defmodule Companion.Repo.Migrations.CreateApplications do
+  use Ecto.Migration
+
+  def change do
+    create table(:applications) do
+      add :name, :string
+      add :token, :uuid
+
+      timestamps()
+    end
+
+  end
+end

--- a/test/companion/companion_web/companion_web_test.exs
+++ b/test/companion/companion_web/companion_web_test.exs
@@ -10,13 +10,13 @@ defmodule Companion.CompanionWebTest do
     @update_attrs %{name: "some updated name", token: "7488a646-e31f-11e4-aace-600308960668"}
     @invalid_attrs %{name: nil, token: nil}
 
-    def application_fixture(attrs \\ %{}) do
-      {:ok, application} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> CompanionWeb.create_application()
+    defp assume_ok({:ok, value}), do: value
 
-      application
+    def application_fixture(attrs \\ %{}) do
+      attrs
+      |> Enum.into(@valid_attrs)
+      |> CompanionWeb.create_application()
+      |> assume_ok()
     end
 
     test "list_applications/0 returns all applications" do

--- a/test/companion/companion_web/companion_web_test.exs
+++ b/test/companion/companion_web/companion_web_test.exs
@@ -1,0 +1,68 @@
+defmodule Companion.CompanionWebTest do
+  use Companion.DataCase
+
+  alias Companion.CompanionWeb
+
+  describe "applications" do
+    alias Companion.CompanionWeb.Application
+
+    @valid_attrs %{name: "some name", token: "7488a646-e31f-11e4-aace-600308960662"}
+    @update_attrs %{name: "some updated name", token: "7488a646-e31f-11e4-aace-600308960668"}
+    @invalid_attrs %{name: nil, token: nil}
+
+    def application_fixture(attrs \\ %{}) do
+      {:ok, application} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> CompanionWeb.create_application()
+
+      application
+    end
+
+    test "list_applications/0 returns all applications" do
+      application = application_fixture()
+      assert CompanionWeb.list_applications() == [application]
+    end
+
+    test "get_application!/1 returns the application with given id" do
+      application = application_fixture()
+      assert CompanionWeb.get_application!(application.id) == application
+    end
+
+    test "create_application/1 with valid data creates a application" do
+      assert {:ok, %Application{} = application} = CompanionWeb.create_application(@valid_attrs)
+      assert application.name == "some name"
+    end
+
+    test "create_application/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = CompanionWeb.create_application(@invalid_attrs)
+    end
+
+    test "update_application/2 with valid data updates the application" do
+      application = application_fixture()
+      assert {:ok, application} = CompanionWeb.update_application(application, @update_attrs)
+      assert %Application{} = application
+      assert application.name == "some updated name"
+    end
+
+    test "update_application/2 with invalid data returns error changeset" do
+      application = application_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               CompanionWeb.update_application(application, @invalid_attrs)
+
+      assert application == CompanionWeb.get_application!(application.id)
+    end
+
+    test "delete_application/1 deletes the application" do
+      application = application_fixture()
+      assert {:ok, %Application{}} = CompanionWeb.delete_application(application)
+      assert_raise Ecto.NoResultsError, fn -> CompanionWeb.get_application!(application.id) end
+    end
+
+    test "change_application/1 returns a application changeset" do
+      application = application_fixture()
+      assert %Ecto.Changeset{} = CompanionWeb.change_application(application)
+    end
+  end
+end

--- a/test/companion_web/controllers/application_controller_test.exs
+++ b/test/companion_web/controllers/application_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule CompanionWeb.ApplicationControllerTest do
+  use CompanionWeb.ConnCase
+
+  alias Companion.CompanionWeb
+
+  @user %{email: "test@example.org", provider: "google"}
+  @create_attrs %{name: "some name"}
+
+  def fixture(:application) do
+    {:ok, application} = CompanionWeb.create_application(@create_attrs)
+    application
+  end
+
+  describe "index" do
+    test "lists all applications", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:user, @user)
+        |> get(application_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "Name"
+    end
+  end
+
+  describe "create application" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:user, @user)
+        |> post(application_path(conn, :create), application: @create_attrs)
+
+      assert redirected_to(conn) == application_path(conn, :index)
+    end
+  end
+
+  describe "delete application" do
+    setup [:create_application]
+
+    test "deletes chosen application", %{conn: conn, application: application} do
+      conn =
+        conn
+        |> assign(:user, @user)
+        |> delete(application_path(conn, :delete, application))
+
+      assert redirected_to(conn) == application_path(conn, :index)
+    end
+  end
+
+  defp create_application(_) do
+    application = fixture(:application)
+    {:ok, application: application}
+  end
+end

--- a/test/companion_web/controllers/page_controller_test.exs
+++ b/test/companion_web/controllers/page_controller_test.exs
@@ -12,6 +12,6 @@ defmodule CompanionWeb.PageControllerTest do
       |> assign(:user, %{email: "foo@example.org", provider: "google"})
       |> get("/")
 
-    assert html_response(conn, 200) =~ "Welcome to the NurseConnect Companion"
+    assert html_response(conn, 200) =~ "NurseConnect Companion"
   end
 end

--- a/test/controllers/apiroot_controller_test.exs
+++ b/test/controllers/apiroot_controller_test.exs
@@ -2,7 +2,6 @@ defmodule Companion.ApiRootControllerTest do
   use CompanionWeb.ConnCase
 
   alias Companion.CompanionWeb.Application
-  alias Companion.Repo
 
   @application %Application{name: "test", token: Ecto.UUID.generate()}
 

--- a/test/controllers/apiroot_controller_test.exs
+++ b/test/controllers/apiroot_controller_test.exs
@@ -1,0 +1,25 @@
+defmodule Companion.ApiRootControllerTest do
+  use CompanionWeb.ConnCase
+
+  alias Companion.CompanionWeb.Application
+  alias Companion.Repo
+
+  @application %Application{name: "test", token: Ecto.UUID.generate()}
+
+  test "returns empty response for root", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:application, @application)
+      |> get(api_root_path(conn, :index))
+
+    assert json_response(conn, :ok) == %{}
+  end
+
+  test "returns 401 response for root if not authenticated", %{conn: conn} do
+    conn =
+      conn
+      |> get(api_root_path(conn, :index))
+
+    assert response(conn, :unauthorized) == ""
+  end
+end

--- a/test/controllers/application_controller_test.exs
+++ b/test/controllers/application_controller_test.exs
@@ -1,0 +1,60 @@
+defmodule Companion.ApplicationControllerTest do
+  use CompanionWeb.ConnCase
+
+  alias Companion.CompanionWeb.Application
+  alias Companion.Repo
+
+  @valid_attrs %{name: "some name"}
+  @invalid_attrs %{}
+  @user %{email: "test@example.org", provider: "google"}
+
+  test "lists all entries on index", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:user, @user)
+      |> get(application_path(conn, :index))
+
+    assert html_response(conn, 200) =~ "Name"
+  end
+
+  test "renders form on index", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:user, @user)
+      |> get(application_path(conn, :index))
+
+    assert html_response(conn, 200) =~ "form"
+  end
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:user, @user)
+      |> post(application_path(conn, :create), application: @valid_attrs)
+
+    application = Repo.get_by!(Application, @valid_attrs)
+    assert application.name == @valid_attrs.name
+    assert redirected_to(conn) == application_path(conn, :index)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:user, @user)
+      |> post(application_path(conn, :create), application: @invalid_attrs)
+
+    assert html_response(conn, 200) =~ "Name"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    application = Repo.insert!(%Application{})
+
+    conn =
+      conn
+      |> assign(:user, @user)
+      |> delete(application_path(conn, :delete, application))
+
+    assert redirected_to(conn) == application_path(conn, :index)
+    refute Repo.get(Application, application.id)
+  end
+end

--- a/test/models/application_test.exs
+++ b/test/models/application_test.exs
@@ -1,0 +1,18 @@
+defmodule Companion.ApplicationTest do
+  use Companion.DataCase
+
+  alias Companion.CompanionWeb.Application
+
+  @valid_attrs %{name: "some name", token: "7488a646-e31f-11e4-aace-600308960662"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Application.changeset(%Application{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Application.changeset(%Application{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end


### PR DESCRIPTION
We want to be able to control access to the API through a token in the header.

We also want to be able to easily create an remove these tokens for the various applications that want to use the API, ie. have a UI for managing the tokens