### PR TITLE
Add HSM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ Environment config:
 `OPENHIM_URL` - URL to send to OpenHIM
 `OPENHIM_USERNAME` - Username to access OpenHIM
 `OPENHIM_PASSWORD` - Password to access OpenHIM
+`WHATSAPP_URL` - URL of the WhatsApp instance
+`WHATSAPP_USERNAME` - Username for WhatsApp instance auth
+`WHATSAPP_PASSWORD` - Password for WhatsApp instance auth
+`WHATSAPP_HSM_NAMESPACE` - The HSM namespace to use for the send HSM endpoint
+`WHATSAPP_HSM_ELEMENT_NAME` - The HSM element name to use for the send HSM endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -60,6 +60,14 @@ config :companion, :openhim,
   username: System.get_env("OPENHIM_USERNAME") || "user",
   password: System.get_env("OPENHIM_PASSWORD") || "pass"
 
+# Whatsapp config
+config :companion, :whatsapp,
+  url: System.get_env("WHATSAPP_URL") || "https://whatsapp",
+  username: System.get_env("WHATSAPP_USERNAME") || "user",
+  password: System.get_env("WHATSAPP_PASSWORD") || "pass",
+  hsm_namespace: System.get_env("WHATSAPP_HSM_NAMESPACE") || "hsm_namespace",
+  hsm_element_name: System.get_env("WHATSAPP_HSM_ELEMENT_NAME") || "hsm_element_name"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -37,3 +37,11 @@ config :companion, :openhim,
   url: "http://openhim",
   username: "user",
   password: "pass"
+
+# Whatsapp config
+config :companion, :whatsapp,
+  url: "https://whatsapp",
+  username: "user",
+  password: "pass",
+  hsm_namespace: "hsm_namespace",
+  hsm_element_name: "hsm_element_name"

--- a/lib/companion/application.ex
+++ b/lib/companion/application.ex
@@ -14,6 +14,9 @@ defmodule Companion.Application do
       supervisor(Companion.Repo, []),
       # Start the endpoint when the application starts
       supervisor(CompanionWeb.Endpoint, []),
+      # Caches
+      {ConCache,
+       [name: :whatsapp_token, ttl_check_interval: :timer.minutes(1), global_ttl: :infinity]},
       # Jobs
       {Honeydew.EctoPollQueue, Jobs.ProcessOptOut.supervisor_config()},
       {Honeydew.Workers, [:process_opt_out, Jobs.ProcessOptOut]}

--- a/lib/companion_web/clients/whatsapp.ex
+++ b/lib/companion_web/clients/whatsapp.ex
@@ -1,0 +1,53 @@
+defmodule CompanionWeb.Clients.Whatsapp do
+  @moduledoc """
+  A client for the WhatsApp API. Only implements the endpoints that we require
+  """
+  use Tesla
+
+  plug Tesla.Middleware.BaseUrl, Application.get_env(:companion, :whatsapp)[:url]
+  plug Tesla.Middleware.JSON, engine: Poison
+
+  @doc """
+  Get the token and expiry for the configured WhatsApp user
+  """
+  def login! do
+    config = Application.get_env(:companion, :whatsapp)
+
+    %{body: %{"users" => [%{"token" => token, "expires_after" => expires} | _]}} =
+      post!(
+        "/v1/users/login",
+        %{},
+        headers: [authorization: "Basic " <> basic_auth(config[:username], config[:password])]
+      )
+
+    {token, expires}
+  end
+
+  defp basic_auth(username, password) do
+    Base.encode64("#{username}:#{password}")
+  end
+
+  @doc """
+  Build the client with a runtime token argument
+  """
+  def client(token) do
+    Tesla.build_client([
+      {Tesla.Middleware.Headers, [{"authorization", "Bearer " <> token}]}
+    ])
+  end
+
+  @doc """
+  Given the address and message, sends the HSM
+  """
+  def send_hsm!(client, to, message) do
+    post!(client, "/v1/messages", %{
+      to: to,
+      type: "hsm",
+      hsm: %{
+        namespace: Application.get_env(:companion, :whatsapp)[:hsm_namespace],
+        element_name: Application.get_env(:companion, :whatsapp)[:hsm_element_name],
+        localizable_params: [%{default: message}]
+      }
+    })
+  end
+end

--- a/lib/companion_web/controllers/fallback_controller.ex
+++ b/lib/companion_web/controllers/fallback_controller.ex
@@ -18,3 +18,13 @@ defmodule CompanionWeb.FallbackController do
     |> render(CompanionWeb.ErrorView, :"404", %{})
   end
 end
+
+defmodule CompanionWeb.FallbackHSMController do
+  use CompanionWeb, :controller
+
+  def call(conn, {:error, :bad_request, reason}) do
+    conn
+    |> put_status(:bad_request)
+    |> render(CompanionWeb.HSMView, "error.json", reason: reason)
+  end
+end

--- a/lib/companion_web/controllers/hsm_controller.ex
+++ b/lib/companion_web/controllers/hsm_controller.ex
@@ -1,0 +1,143 @@
+defmodule CompanionWeb.HSMController do
+  use CompanionWeb, :controller
+  use PhoenixSwagger
+
+  action_fallback CompanionWeb.FallbackHSMController
+
+  alias CompanionWeb.Clients.Whatsapp
+
+  def swagger_definitions do
+    %{
+      HSMRequest:
+        swagger_schema do
+          title("HSMRequest")
+          description("Schema for an HSM request")
+
+          properties do
+            contact(
+              Schema.new do
+                properties do
+                  urn(
+                    :string,
+                    "URN of the contact. Must be of type whatsapp",
+                    required: true,
+                    format: :urn
+                  )
+                end
+              end
+            )
+          end
+
+          example(%{
+            contact: %{
+              urn: "whatsapp:27820000000"
+            }
+          })
+        end,
+      HSMMessage:
+        swagger_schema do
+          title("HSMMessage")
+          description("Response schema for an HSM message")
+
+          properties do
+            id(:string, "ID of the sent message", format: :uuid)
+          end
+
+          example(%{
+            id: "gBEGkYiEB1VXAglK1ZEqA1YKPrU"
+          })
+        end,
+      HSMResponse:
+        swagger_schema do
+          title("HSM Response")
+          description("Response schema for HSM creation")
+
+          properties do
+            messages(
+              Schema.new do
+                type(:array)
+                items(Schema.ref(:HSMMessage))
+              end
+            )
+          end
+        end
+    }
+  end
+
+  swagger_path(:create) do
+    summary("Create HSM")
+    description("Creates a new HSM")
+    consumes("application/json")
+    produces("application/json")
+
+    parameter(
+      "X-Message-Content",
+      :header,
+      :string,
+      "Message content for the HSM",
+      required: true
+    )
+
+    parameters do
+      body(:body, Schema.ref(:HSMRequest), "The details of the HSM to be created")
+    end
+
+    response(
+      201,
+      "HSM created OK",
+      Schema.ref(:HSMResponse)
+    )
+  end
+
+  def create(conn, %{"contact" => %{"urn" => urn}}) do
+    with {:ok, address} <- get_address_from_urn(urn),
+         {:ok, message} <- get_message_from_header(conn) do
+      response =
+        ConCache.get_or_store(:whatsapp_token, :whatsapp_token, fn ->
+          {token, expire} = Whatsapp.login!()
+
+          seconds =
+            Timex.Interval.new(
+              from: Timex.now(),
+              # We should expire 5 minutes before the token expires
+              until: Timex.shift(Timex.parse!(expire, "{ISO:Extended}"), minutes: -5)
+            )
+            |> Timex.Interval.duration(:seconds)
+
+          %ConCache.Item{value: token, ttl: :timer.seconds(seconds)}
+        end)
+        |> Whatsapp.client()
+        |> Whatsapp.send_hsm!(address, message)
+
+      conn
+      |> put_status(:created)
+      |> render("create.json", response: response.body)
+    end
+  end
+
+  def create(_, _) do
+    {:error, :bad_request, "Missing contact URN"}
+  end
+
+  defp get_address_from_urn("whatsapp:" <> address) do
+    {:ok, address}
+  end
+
+  defp get_address_from_urn(urn) do
+    {:error, :bad_request, "Invalid WhatsApp URN: #{urn}"}
+  end
+
+  defp get_message_from_header(%Plug.Conn{} = conn) do
+    conn
+    |> get_req_header("x-message-content")
+    |> get_message_from_header()
+  end
+
+  defp get_message_from_header([message]) do
+    {:ok, message}
+  end
+
+  defp get_message_from_header(_) do
+    {:error, :bad_request, "X-Message-Content header must be supplied"}
+  end
+end

--- a/lib/companion_web/router.ex
+++ b/lib/companion_web/router.ex
@@ -48,6 +48,7 @@ defmodule CompanionWeb.Router do
 
     get "/", ApiRootController, :index
     resources "/optouts", OptOutController, only: [:create, :show]
+    resources "/hsm", HSMController, only: [:create]
   end
 
   scope "/api/docs" do

--- a/lib/companion_web/views/hsm_view.ex
+++ b/lib/companion_web/views/hsm_view.ex
@@ -1,0 +1,11 @@
+defmodule CompanionWeb.HSMView do
+  use CompanionWeb, :view
+
+  def render("create.json", %{response: response}) do
+    response
+  end
+
+  def render("error.json", %{reason: reason}) do
+    %{error: reason}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Companion.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test --no-start"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Companion.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test --no-start"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -58,6 +58,8 @@ defmodule Companion.Mixfile do
       {:honeydew, "~> 1.1.5"},
       {:tesla, "~> 1.0.0"},
       {:poison, "~> 3.1"},
+      # We're using con_cache instead of cachex because we want to set TTL on a fetch
+      {:con_cache, "~> 0.13.0"},
 
       # Dev/test/build tools.
       {:excoveralls, "~> 0.8", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
+  "con_cache": {:hex, :con_cache, "0.13.0", "fe30eeffc776465b596a60d5bc7f81083fd90aeeeb5d72b98a957fb4a78e4378", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},

--- a/test/clients/whatsapp_test.exs
+++ b/test/clients/whatsapp_test.exs
@@ -1,0 +1,66 @@
+defmodule Companion.Clients.WhatsappTest do
+  use ExUnit.Case
+  import Tesla.Mock
+  alias CompanionWeb.Clients.Whatsapp
+
+  @empty_json Poison.encode!(%{})
+  @hsm_request Poison.encode!(%{
+                 to: "27820000000",
+                 type: "hsm",
+                 hsm: %{
+                   namespace: "hsm_namespace",
+                   element_name: "hsm_element_name",
+                   localizable_params: [%{default: "test message"}]
+                 }
+               })
+
+  setup do
+    mock(fn
+      %{
+        method: :post,
+        url: "https://whatsapp/v1/users/login",
+        headers: [{:authorization, "Basic dXNlcjpwYXNz"}, {"content-type", "application/json"}],
+        body: @empty_json
+      } ->
+        json(%{
+          users: [
+            %{
+              token: "testtoken",
+              expires_after: "2018-09-11 12:48:55+00:00"
+            }
+          ]
+        })
+
+      %{
+        method: :post,
+        url: "https://whatsapp/v1/messages",
+        headers: [
+          {"authorization", "Bearer testtoken"},
+          {"content-type", "application/json"}
+        ],
+        body: @hsm_request
+      } ->
+        json(%{
+          messages: [%{id: "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]
+        })
+    end)
+
+    :ok
+  end
+
+  test "login! gets token and expiry" do
+    {token, expires} = Whatsapp.login!()
+    assert token == "testtoken"
+    assert expires == "2018-09-11 12:48:55+00:00"
+  end
+
+  test "send_hsm! makes a request to send the templated message" do
+    %{body: body} =
+      Whatsapp.login!()
+      |> elem(0)
+      |> Whatsapp.client()
+      |> Whatsapp.send_hsm!("27820000000", "test message")
+
+    assert body == %{"messages" => [%{"id" => "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]}
+  end
+end

--- a/test/companion_web/controllers/hsm_controller_test.exs
+++ b/test/companion_web/controllers/hsm_controller_test.exs
@@ -1,0 +1,102 @@
+defmodule CompanionWeb.HSMControllerTest do
+  use CompanionWeb.ConnCase
+  use PhoenixSwagger.SchemaTest, "priv/static/swagger.json"
+
+  alias Companion.CompanionWeb.Application
+  import Tesla.Mock
+
+  @application %Application{name: "test", token: Ecto.UUID.generate()}
+  @create_attrs %{
+    contact: %{uuid: "b8225caf-cd55-47f8-8e2f-11206571bf1f", urn: "whatsapp:27820000000"}
+  }
+  @invalid_create_attrs %{
+    contact: %{uuid: "b8225caf-cd55-47f8-8e2f-11206571bf1f", urn: "tel:+27820000000"}
+  }
+  @empty_json Poison.encode!(%{})
+  @hsm_request Poison.encode!(%{
+                 to: "27820000000",
+                 type: "hsm",
+                 hsm: %{
+                   namespace: "hsm_namespace",
+                   element_name: "hsm_element_name",
+                   localizable_params: [%{default: "Test message"}]
+                 }
+               })
+
+  setup do
+    mock(fn
+      %{
+        method: :post,
+        url: "https://whatsapp/v1/users/login",
+        headers: [{:authorization, "Basic dXNlcjpwYXNz"}, {"content-type", "application/json"}],
+        body: @empty_json
+      } ->
+        json(%{
+          users: [
+            %{
+              token: "testtoken",
+              expires_after: "2018-09-11 12:48:55+00:00"
+            }
+          ]
+        })
+
+      %{
+        method: :post,
+        url: "https://whatsapp/v1/messages",
+        headers: [
+          {"authorization", "Bearer testtoken"},
+          {"content-type", "application/json"}
+        ],
+        body: @hsm_request
+      } ->
+        json(%{
+          messages: [%{id: "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]
+        })
+    end)
+
+    :ok
+  end
+
+  describe "create hsm" do
+    test "renders hsm when data is valid", %{conn: conn, swagger_schema: schema} do
+      conn =
+        conn
+        |> assign(:application, @application)
+        |> put_req_header("x-message-content", "Test message")
+        |> post(hsm_path(conn, :create), @create_attrs)
+        |> validate_resp_schema(schema, "HSMResponse")
+
+      assert %{"messages" => [%{"id" => "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]} =
+               json_response(conn, 201)
+    end
+
+    test "renders error when x-message-content header is missing", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:application, @application)
+        |> post(hsm_path(conn, :create), @create_attrs)
+
+      assert %{"error" => "X-Message-Content header must be supplied"} = json_response(conn, 400)
+    end
+
+    test "renders error when contact details are missing", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:application, @application)
+        |> put_req_header("x-message-content", "Test message")
+        |> post(hsm_path(conn, :create), %{})
+
+      assert %{"error" => "Missing contact URN"} = json_response(conn, 400)
+    end
+
+    test "renders error when contact URN is invalid", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:application, @application)
+        |> put_req_header("x-message-content", "Test message")
+        |> post(hsm_path(conn, :create), @invalid_create_attrs)
+
+      assert %{"error" => "Invalid WhatsApp URN: tel:+27820000000"} = json_response(conn, 400)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,17 +1,3 @@
-# Start the repo and endpoint required for tests
-import Supervisor.Spec
-
-children = [
-  supervisor(Companion.Repo, []),
-  supervisor(CompanionWeb.Endpoint, [])
-]
-
-opts = [strategy: :one_for_one, name: Companion.Supervisor]
-Supervisor.start_link(children, opts)
-# Ensure that the application has started
-Application.ensure_all_started(:companion)
-Application.ensure_all_started(:timex)
-
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Companion.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,17 @@
+# Start the repo and endpoint required for tests
+import Supervisor.Spec
+
+children = [
+  supervisor(Companion.Repo, []),
+  supervisor(CompanionWeb.Endpoint, [])
+]
+
+opts = [strategy: :one_for_one, name: Companion.Supervisor]
+Supervisor.start_link(children, opts)
+# Ensure that the application has started
+Application.ensure_all_started(:companion)
+Application.ensure_all_started(:timex)
+
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Companion.Repo, :manual)


### PR DESCRIPTION
Add an endpoint to receive webhooks from RapidPro, and send through the details to the WhatsApp API to send an HSM