### PR TITLE
Add contact check for HSM sends

### DIFF
--- a/lib/companion_web/clients/whatsapp.ex
+++ b/lib/companion_web/clients/whatsapp.ex
@@ -29,6 +29,29 @@ defmodule CompanionWeb.Clients.Whatsapp do
     |> raise_for_status()
   end
 
+  def contact_check(address) do
+    post("/v1/contacts", %{
+      blocking: "wait",
+      contacts: [address]
+    })
+    |> raise_for_status()
+    |> get_contact_id()
+  end
+
+  defp get_contact_id({:ok, %Tesla.Env{} = resp}) do
+    get_contact_id({:ok, resp.body})
+  end
+
+  defp get_contact_id({:ok, %{"contacts" => [%{"wa_id" => id}]}}) do
+    {:ok, id}
+  end
+
+  defp get_contact_id({:ok, %{} = _}) do
+    {:error, 404, "Cannot find WhatsApp contact"}
+  end
+
+  defp get_contact_id(error), do: error
+
   defp raise_for_status({:ok, response}) do
     case response.status do
       status when status in 200..299 ->

--- a/lib/companion_web/controllers/fallback_controller.ex
+++ b/lib/companion_web/controllers/fallback_controller.ex
@@ -28,8 +28,13 @@ defmodule CompanionWeb.FallbackHSMController do
     |> render(CompanionWeb.HSMView, "error.json", reason: reason)
   end
 
+  def call(conn, {:error, status, %{} = reason}) do
+    conn
+    |> send_resp(status, Poison.encode!(reason))
+  end
+
   def call(conn, {:error, status, reason}) do
     conn
-    |> send_resp(status, reason)
+    |> send_resp(status, "#{reason}")
   end
 end

--- a/test/companion_web/controllers/hsm_controller_test.exs
+++ b/test/companion_web/controllers/hsm_controller_test.exs
@@ -55,7 +55,7 @@ defmodule CompanionWeb.HSMControllerTest do
         ],
         body: @bad_hsm_request
       } ->
-        %Tesla.Env{status: 500, body: "Error"}
+        %Tesla.Env{status: 404, body: %{"bad" => "request"}}
     end)
 
     :ok
@@ -110,7 +110,7 @@ defmodule CompanionWeb.HSMControllerTest do
         |> put_req_header("x-message-content", "Bad message")
         |> post(hsm_path(conn, :create), @create_attrs)
 
-      assert "Error" = response(conn, 500)
+      assert ~s({"bad":"request"}) = response(conn, 404)
     end
   end
 end

--- a/test/companion_web/controllers/hsm_controller_test.exs
+++ b/test/companion_web/controllers/hsm_controller_test.exs
@@ -10,7 +10,7 @@ defmodule CompanionWeb.HSMControllerTest do
     contact: %{uuid: "b8225caf-cd55-47f8-8e2f-11206571bf1f", urn: "whatsapp:27820000000"}
   }
   @invalid_create_attrs %{
-    contact: %{uuid: "b8225caf-cd55-47f8-8e2f-11206571bf1f", urn: "tel:+27820000000"}
+    contact: %{uuid: "b8225caf-cd55-47f8-8e2f-11206571bf1f", urn: "+27820000000"}
   }
   @hsm_request Poison.encode!(%{
                  to: "27820000000",
@@ -21,6 +21,10 @@ defmodule CompanionWeb.HSMControllerTest do
                    localizable_params: [%{default: "Test message"}]
                  }
                })
+  @contact_request Poison.encode!(%{
+                     contacts: ["27820000000"],
+                     blocking: "wait"
+                   })
   @bad_hsm_request Poison.encode!(%{
                      to: "27820000000",
                      type: "hsm",
@@ -44,6 +48,19 @@ defmodule CompanionWeb.HSMControllerTest do
       } ->
         json(%{
           messages: [%{id: "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]
+        })
+
+      %{
+        method: :post,
+        url: "https://whatsapp/v1/contacts",
+        headers: [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer token"}
+        ],
+        body: @contact_request
+      } ->
+        json(%{
+          contacts: [%{wa_id: "27820000000"}]
         })
 
       %{
@@ -100,7 +117,7 @@ defmodule CompanionWeb.HSMControllerTest do
         |> put_req_header("x-message-content", "Test message")
         |> post(hsm_path(conn, :create), @invalid_create_attrs)
 
-      assert %{"error" => "Invalid WhatsApp URN: tel:+27820000000"} = json_response(conn, 400)
+      assert %{"error" => "Invalid WhatsApp URN: +27820000000"} = json_response(conn, 400)
     end
 
     test "renders error when there is a client error", %{conn: conn} do


### PR DESCRIPTION
Before we can send to a contact, we need to do a contact check, even for HSM messages.

This PR adds a contact check before each HSM request, as well as using the result of that check for the sending address, to make the sends more robust against normal MSISDNs being sent in