### PR TITLE
Migration for changing templatemessages content varchar to text

### DIFF
--- a/priv/repo/migrations/20190131140235_varchar_to_text.exs
+++ b/priv/repo/migrations/20190131140235_varchar_to_text.exs
@@ -1,0 +1,9 @@
+defmodule Companion.Repo.Migrations.VarcharToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:templatemessages) do
+      modify :content, :text
+    end
+  end
+end


### PR DESCRIPTION
For the templatemessages table, currently the `content` field is a varchar with
a limit of 255 characters. Our message content, however, can be more than 255
characters, so we should change to using a text field for this, which has no
character limit.