### PR TITLE
Custom template message support

### DIFF
--- a/assets/css/app.sass
+++ b/assets/css/app.sass
@@ -1,2 +1,5 @@
 @import 'bootstrap'
 @import 'font-awesome'
+
+.hide
+    display: none !important

--- a/lib/companion/companion_web/template_message.ex
+++ b/lib/companion/companion_web/template_message.ex
@@ -7,9 +7,10 @@ defmodule Companion.CompanionWeb.TemplateMessage do
   import Honeydew.EctoPollQueue.Schema
 
   schema "templatemessages" do
-    field(:content, :string)
     field(:external_id, :string)
     field(:to, :string)
+    field(:template, :string)
+    field(:variables, {:array, :string})
 
     timestamps()
 
@@ -19,7 +20,7 @@ defmodule Companion.CompanionWeb.TemplateMessage do
   @doc false
   def changeset(template_message, attrs) do
     template_message
-    |> cast(attrs, [:to, :content, :external_id])
-    |> validate_required([:to, :content])
+    |> cast(attrs, [:to, :external_id, :template, :variables])
+    |> validate_required([:to, :template, :variables])
   end
 end

--- a/lib/companion_web/clients/whatsapp.ex
+++ b/lib/companion_web/clients/whatsapp.ex
@@ -16,14 +16,14 @@ defmodule CompanionWeb.Clients.Whatsapp do
   @doc """
   Given the address and message, sends the HSM
   """
-  def send_hsm(to, message) do
+  def send_hsm(to, template, variables) do
     post("/v1/messages", %{
       to: to,
       type: "hsm",
       hsm: %{
         namespace: Application.get_env(:companion, :whatsapp)[:hsm_namespace],
-        element_name: Application.get_env(:companion, :whatsapp)[:hsm_element_name],
-        localizable_params: [%{default: message}]
+        element_name: template,
+        localizable_params: Enum.map(variables, fn v -> %{default: v} end)
       }
     })
     |> raise_for_status()

--- a/lib/companion_web/controllers/flow_generator_controller.ex
+++ b/lib/companion_web/controllers/flow_generator_controller.ex
@@ -12,7 +12,7 @@ defmodule CompanionWeb.FlowGeneratorController do
     application = CompanionWeb.get_application!(params["application"])
 
     conn
-    |> put_resp_content_type("application/json")
+    |> put_resp_content_type("text/html")
     |> put_resp_header("content-disposition", "attachment; filename=send_#{params["date"]}.json")
     # We need to use the `jsonr` extension for the template, else Phoenix stringifys our json
     # before sending it

--- a/lib/companion_web/controllers/hsm_controller.ex
+++ b/lib/companion_web/controllers/hsm_controller.ex
@@ -93,7 +93,12 @@ defmodule CompanionWeb.HSMController do
     with {:ok, address} <- get_address_from_urn(urn),
          {:ok, message} <- get_message_from_header(conn),
          {:ok, wa_id} <- Whatsapp.contact_check(address),
-         {:ok, response} <- Whatsapp.send_hsm(wa_id, message) do
+         {:ok, response} <-
+           Whatsapp.send_hsm(
+             wa_id,
+             Application.get_env(:companion, :whatsapp)[:hsm_element_name],
+             [message]
+           ) do
       conn
       |> put_status(:created)
       |> render("create.json", response: response.body)

--- a/lib/companion_web/jobs/send_template_message.ex
+++ b/lib/companion_web/jobs/send_template_message.ex
@@ -25,7 +25,7 @@ defmodule Companion.Jobs.SendTemplateMessage do
   def run(id) do
     with message = get_template_message!(id),
          {:ok, wa_id} <- Whatsapp.contact_check(message.to),
-         {:ok, response} <- Whatsapp.send_hsm(wa_id, message.content),
+         {:ok, response} <- Whatsapp.send_hsm(wa_id, message.template, message.variables),
          [whatsapp_message] <- response.body["messages"],
          {:ok, _} <- update_template_message(message, %{external_id: whatsapp_message["id"]}) do
       {:ok}

--- a/lib/companion_web/templates/flow_generator/flow.jsonr.eex
+++ b/lib/companion_web/templates/flow_generator/flow.jsonr.eex
@@ -45,7 +45,7 @@
             {
               "type": "api",
               "uuid": "<%= Ecto.UUID.generate %>",
-              "webhook": "<%= template_message_url(@conn, :create, content: @form["whatsapp"]) %>",
+              "webhook": "<%= template_message_url(@conn, :create, template: @form["whatsapp_template"], variable: @form["whatsapp_variable"]) %>",
               "action": "POST",
               "webhook_headers": [
                 {

--- a/lib/companion_web/templates/flow_generator/index.html.eex
+++ b/lib/companion_web/templates/flow_generator/index.html.eex
@@ -9,13 +9,25 @@
         </select>
     </div>
     <div class="form-group">
-        <label for="whatsappContent">WhatsApp Content</label>
-        <textarea class="form-control" id="whatsappContent" rows=3 required name="whatsapp" oninput="generate_url()"></textarea>
-    </div>
-    <div class="form-group">
         <label for="smsContent">SMS Content</label>
         <textarea class="form-control" id="smsContent" rows=3 required name="sms"></textarea>
     </div>
+    <div class="form-group">
+        <label for="whatsappTemplate">WhatsApp Template</label>
+        <input type="text" class="form-control" id="whatsappTemplate" required name="whatsapp_template" oninput="generate_url()"></input>
+    </div>
+    <div class="form-group" id="variables">
+        <label>WhatsApp Variables</label>
+        <input type="text" class="form-control" name="whatsapp_variable[]" oninput="generate_url()"></input>
+        <button class="btn btn-success add-more" type="button" id="add_variable" onclick="addVariable()"><i class="fa fa-plus"></i></button>
+    </div>
+
+    <!-- This is the div we copy to add more variable inputs -->
+    <div class="input-group hide" id="whatsapp_variable_input">
+        <input type="text" class="form-control" oninput="generate_url()"></input>
+        <button class="btn btn-danger" type="button" onclick="removeVariable(this)"><i class="fa fa-times"></i></button>
+    </div>
+
     <div class="form-group">
         <label for="sendDate">Send Date</label>
         <input type="date" class="form-control" id="sendDate" required name="date" />
@@ -29,12 +41,32 @@
 </div>
 
 <script>
-var input = document.getElementById("whatsappContent");
+var template = document.getElementById("whatsappTemplate");
 var output = document.getElementById("hookUrl");
 var url = new URL("<%= template_message_url(@conn, :create) %>");
 function generate_url(){
-    url.searchParams.set("content", input.value);
+    var variables = document.getElementById("variables").getElementsByTagName("input");
+    url.searchParams.delete("variable[]");
+    for (const v of variables) {
+        url.searchParams.append("variable[]", v.value);
+    }
+    url.searchParams.set("template", template.value);
     output.value = url.toString();
+}
+function addVariable(){
+    var variables = document.getElementById("variables");
+    var variable = document.getElementById("whatsapp_variable_input").cloneNode(true);
+    variable.classList.remove("hide");
+    variable.firstElementChild.value = "";
+    variable.firstElementChild.name = "whatsapp_variable[]";
+    // Add before the button
+    variables.insertBefore(variable, document.getElementById("add_variable"));
+    generate_url();
+}
+function removeVariable(node) {
+    var variable = node.parentNode;
+    variable.parentNode.removeChild(variable);
+    generate_url();
 }
 generate_url();
 </script>

--- a/lib/companion_web/views/template_message_view.ex
+++ b/lib/companion_web/views/template_message_view.ex
@@ -10,7 +10,8 @@ defmodule CompanionWeb.TemplateMessageView do
     %{
       id: template_message.id,
       to: template_message.to,
-      content: template_message.content,
+      template: template_message.template,
+      variables: template_message.variables,
       external_id: template_message.external_id
     }
   end

--- a/priv/repo/migrations/20190225141832_template_multi_variables.exs
+++ b/priv/repo/migrations/20190225141832_template_multi_variables.exs
@@ -1,0 +1,11 @@
+defmodule Companion.Repo.Migrations.TemplateMultiVariables do
+  use Ecto.Migration
+
+  def change do
+    alter table(:templatemessages) do
+      remove :content
+      add :template, :text
+      add :variables, {:array, :text}
+    end
+  end
+end

--- a/test/clients/whatsapp_test.exs
+++ b/test/clients/whatsapp_test.exs
@@ -67,7 +67,7 @@ defmodule Companion.Clients.WhatsappTest do
   end
 
   test "send_hsm makes a request to send the templated message" do
-    {:ok, %{body: body}} = Whatsapp.send_hsm("27820000000", "test message")
+    {:ok, %{body: body}} = Whatsapp.send_hsm("27820000000", "hsm_element_name", ["test message"])
 
     assert body == %{"messages" => [%{"id" => "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]}
   end

--- a/test/companion/companion_web/companion_web_test.exs
+++ b/test/companion/companion_web/companion_web_test.exs
@@ -130,13 +130,19 @@ defmodule Companion.CompanionWebTest do
   describe "templatemessages" do
     alias Companion.CompanionWeb.TemplateMessage
 
-    @valid_attrs %{content: "some content", external_id: "some external_id", to: "some to"}
-    @update_attrs %{
-      content: "some updated content",
-      external_id: "some updated external_id",
-      to: "some updated to"
+    @valid_attrs %{
+      template: "some template",
+      external_id: "some external_id",
+      to: "some to",
+      variables: ["some", "variables"]
     }
-    @invalid_attrs %{content: nil, external_id: nil, to: nil}
+    @update_attrs %{
+      template: "some updated template",
+      external_id: "some updated external_id",
+      to: "some updated to",
+      variables: ["some", "updated", "variables"]
+    }
+    @invalid_attrs %{template: nil, external_id: nil, to: nil}
 
     def template_message_fixture(attrs \\ %{}) do
       {:ok, template_message} =
@@ -166,9 +172,10 @@ defmodule Companion.CompanionWebTest do
       assert {:ok, %TemplateMessage{} = template_message} =
                CompanionWeb.create_template_message(@valid_attrs)
 
-      assert template_message.content == "some content"
+      assert template_message.template == "some template"
       assert template_message.external_id == "some external_id"
       assert template_message.to == "some to"
+      assert template_message.variables == ["some", "variables"]
     end
 
     test "create_template_message/1 with invalid data returns error changeset" do
@@ -182,9 +189,10 @@ defmodule Companion.CompanionWebTest do
                CompanionWeb.update_template_message(template_message, @update_attrs)
 
       assert %TemplateMessage{} = template_message
-      assert template_message.content == "some updated content"
+      assert template_message.template == "some updated template"
       assert template_message.external_id == "some updated external_id"
       assert template_message.to == "some updated to"
+      assert template_message.variables == ["some", "updated", "variables"]
     end
 
     test "update_template_message/2 with invalid data returns error changeset" do

--- a/test/companion_web/controllers/flow_generator_controller_test.exs
+++ b/test/companion_web/controllers/flow_generator_controller_test.exs
@@ -28,12 +28,14 @@ defmodule CompanionWeb.FlowGeneratorControllerTest do
           application: application.id,
           date: "2018-01-01",
           sms: "sms body",
-          whatsapp: "whatsapp body"
+          whatsapp_template: "whatsapp template",
+          whatsapp_variable: ["var1", "var2"]
         })
 
       [content_disposition_header] = get_resp_header(conn, "content-disposition")
       assert content_disposition_header == "attachment; filename=send_2018-01-01.json"
-      response = json_response(conn, 200)
+      response = html_response(conn, 200)
+      response = Poison.decode!(response)
       assert response["site"] == "http://rapidpro"
 
       assert response
@@ -54,7 +56,12 @@ defmodule CompanionWeb.FlowGeneratorControllerTest do
              |> Map.fetch!("actions")
              |> Enum.at(1)
              |> Map.fetch!("webhook") ==
-               template_message_url(conn, :create, content: "whatsapp body")
+               template_message_url(
+                 conn,
+                 :create,
+                 template: "whatsapp template",
+                 variable: ["var1", "var2"]
+               )
 
       assert response
              |> Map.fetch!("flows")

--- a/test/companion_web/controllers/template_message_controller_test.exs
+++ b/test/companion_web/controllers/template_message_controller_test.exs
@@ -27,7 +27,15 @@ defmodule CompanionWeb.TemplateMessageControllerTest do
       conn =
         conn
         |> assign(:application, @application)
-        |> post(template_message_path(conn, :create, content: "some content"), @create_attrs)
+        |> post(
+          template_message_path(
+            conn,
+            :create,
+            template: "some template",
+            variable: ["some", "variables"]
+          ),
+          @create_attrs
+        )
         |> validate_resp_schema(schema, "TemplateMessageResponse")
 
       assert %{"id" => id} = json_response(conn, 201)
@@ -39,7 +47,8 @@ defmodule CompanionWeb.TemplateMessageControllerTest do
 
       assert json_response(conn, 200) == %{
                "id" => id,
-               "content" => "some content",
+               "template" => "some template",
+               "variables" => ["some", "variables"],
                "external_id" => nil,
                "to" => "+27820000000"
              }
@@ -61,7 +70,7 @@ defmodule CompanionWeb.TemplateMessageControllerTest do
         |> post(template_message_path(conn, :create), @create_attrs)
 
       assert json_response(conn, 400) == %{
-               "error" => "Query string parameter 'content' is required"
+               "error" => "Query string parameter 'template' is required"
              }
     end
   end

--- a/test/jobs/send_template_message_test.exs
+++ b/test/jobs/send_template_message_test.exs
@@ -52,7 +52,13 @@ defmodule Companion.Jobs.SendTemplateMessageTests do
   end
 
   test "Sends the templated message" do
-    {:ok, message} = create_template_message(%{content: "Test message", to: "+27820000000"})
+    {:ok, message} =
+      create_template_message(%{
+        template: "hsm_element_name",
+        to: "+27820000000",
+        variables: ["Test message"]
+      })
+
     SendTemplateMessage.run(message.id)
     message = get_template_message!(message.id)
     assert message.external_id == "gBEGkYiEB1VXAglK1ZEqA1YKPrU"


### PR DESCRIPTION
We require the ability to specify a template name and multiple variables for
our webhooks from RapidPro.

Since nothing is using it yet, we can modify the new v2 templatemessages API
and flow generator to support this.

![image](https://user-images.githubusercontent.com/8234653/53413341-64e3a000-39d4-11e9-9b81-04b323123852.png)
