### PR TITLE
Add langauge parameter to template message requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
     # Run elixir tests
     - elixir: '1.6'
       otp_release: '20.3'
+      services:
+        - postgresql
 
     # Run dialyzer
     - elixir: '1.6'

--- a/lib/companion_web/clients/whatsapp.ex
+++ b/lib/companion_web/clients/whatsapp.ex
@@ -24,7 +24,11 @@ defmodule CompanionWeb.Clients.Whatsapp do
       hsm: %{
         namespace: Application.get_env(:companion, :whatsapp)[:hsm_namespace],
         element_name: template,
-        localizable_params: Enum.map(variables, fn v -> %{default: v} end)
+        localizable_params: Enum.map(variables, fn v -> %{default: v} end),
+        language: %{
+          policy: "deterministic",
+          code: "en"
+        }
       }
     })
     |> raise_for_status()

--- a/lib/companion_web/clients/whatsapp.ex
+++ b/lib/companion_web/clients/whatsapp.ex
@@ -8,7 +8,8 @@ defmodule CompanionWeb.Clients.Whatsapp do
   plug Tesla.Middleware.JSON, engine: Poison
 
   plug Tesla.Middleware.Headers, [
-    {"authorization", "Bearer " <> Application.get_env(:companion, :whatsapp)[:token]}
+    {"authorization", "Bearer " <> Application.get_env(:companion, :whatsapp)[:token]},
+    {"user-agent", "nurseconnect-companion"}
   ]
 
   plug Tesla.Middleware.Logger

--- a/test/clients/whatsapp_test.exs
+++ b/test/clients/whatsapp_test.exs
@@ -9,7 +9,11 @@ defmodule Companion.Clients.WhatsappTest do
                  hsm: %{
                    namespace: "hsm_namespace",
                    element_name: "hsm_element_name",
-                   localizable_params: [%{default: "test message"}]
+                   localizable_params: [%{default: "test message"}],
+                   language: %{
+                     policy: "deterministic",
+                     code: "en"
+                   }
                  }
                })
   @contact_check_request Poison.encode!(%{

--- a/test/clients/whatsapp_test.exs
+++ b/test/clients/whatsapp_test.exs
@@ -28,7 +28,8 @@ defmodule Companion.Clients.WhatsappTest do
         url: "https://whatsapp/v1/messages",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @hsm_request
       } ->
@@ -41,7 +42,8 @@ defmodule Companion.Clients.WhatsappTest do
         url: "https://whatsapp/v1/contacts",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @contact_check_request
       } ->
@@ -54,7 +56,8 @@ defmodule Companion.Clients.WhatsappTest do
         url: "https://whatsapp/v1/contacts",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @missing_contact_check_request
       } ->

--- a/test/companion_web/controllers/hsm_controller_test.exs
+++ b/test/companion_web/controllers/hsm_controller_test.exs
@@ -42,7 +42,8 @@ defmodule CompanionWeb.HSMControllerTest do
         url: "https://whatsapp/v1/messages",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @hsm_request
       } ->
@@ -55,7 +56,8 @@ defmodule CompanionWeb.HSMControllerTest do
         url: "https://whatsapp/v1/contacts",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @contact_request
       } ->
@@ -68,7 +70,8 @@ defmodule CompanionWeb.HSMControllerTest do
         url: "https://whatsapp/v1/messages",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @bad_hsm_request
       } ->

--- a/test/companion_web/controllers/hsm_controller_test.exs
+++ b/test/companion_web/controllers/hsm_controller_test.exs
@@ -18,7 +18,11 @@ defmodule CompanionWeb.HSMControllerTest do
                  hsm: %{
                    namespace: "hsm_namespace",
                    element_name: "hsm_element_name",
-                   localizable_params: [%{default: "Test message"}]
+                   localizable_params: [%{default: "Test message"}],
+                   language: %{
+                     policy: "deterministic",
+                     code: "en"
+                   }
                  }
                })
   @contact_request Poison.encode!(%{
@@ -31,7 +35,11 @@ defmodule CompanionWeb.HSMControllerTest do
                      hsm: %{
                        namespace: "hsm_namespace",
                        element_name: "hsm_element_name",
-                       localizable_params: [%{default: "Bad message"}]
+                       localizable_params: [%{default: "Bad message"}],
+                       language: %{
+                         policy: "deterministic",
+                         code: "en"
+                       }
                      }
                    })
 

--- a/test/jobs/send_template_message_test.exs
+++ b/test/jobs/send_template_message_test.exs
@@ -26,7 +26,8 @@ defmodule Companion.Jobs.SendTemplateMessageTests do
         url: "https://whatsapp/v1/messages",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @hsm_request
       } ->
@@ -39,7 +40,8 @@ defmodule Companion.Jobs.SendTemplateMessageTests do
         url: "https://whatsapp/v1/contacts",
         headers: [
           {"content-type", "application/json"},
-          {"authorization", "Bearer token"}
+          {"authorization", "Bearer token"},
+          {"user-agent", "nurseconnect-companion"}
         ],
         body: @contact_request
       } ->

--- a/test/jobs/send_template_message_test.exs
+++ b/test/jobs/send_template_message_test.exs
@@ -11,7 +11,11 @@ defmodule Companion.Jobs.SendTemplateMessageTests do
                  hsm: %{
                    namespace: "hsm_namespace",
                    element_name: "hsm_element_name",
-                   localizable_params: [%{default: "Test message"}]
+                   localizable_params: [%{default: "Test message"}],
+                   language: %{
+                     policy: "deterministic",
+                     code: "en"
+                   }
                  }
                })
   @contact_request Poison.encode!(%{


### PR DESCRIPTION
The language parameter is required for the WhatsApp API, so we should add it to be able to send templated messages.