### PR TITLE
Endpoint for submitting registrations to OpenHIM

### DIFF
--- a/lib/companion/companion_web/companion_web.ex
+++ b/lib/companion/companion_web/companion_web.ex
@@ -340,4 +340,100 @@ defmodule Companion.CompanionWeb do
   def change_template_message(%TemplateMessage{} = template_message) do
     TemplateMessage.changeset(template_message, %{})
   end
+
+  alias Companion.CompanionWeb.Registration
+
+  @doc """
+  Returns the list of registrations.
+
+  ## Examples
+
+      iex> list_registrations()
+      [%Registration{}, ...]
+
+  """
+  def list_registrations do
+    Repo.all(Registration)
+  end
+
+  @doc """
+  Gets a single registration.
+
+  Raises `Ecto.NoResultsError` if the Registration does not exist.
+
+  ## Examples
+
+      iex> get_registration!(123)
+      %Registration{}
+
+      iex> get_registration!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_registration!(id), do: Repo.get!(Registration, id)
+
+  @doc """
+  Creates a registration.
+
+  ## Examples
+
+      iex> create_registration(%{field: value})
+      {:ok, %Registration{}}
+
+      iex> create_registration(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_registration(attrs \\ %{}) do
+    %Registration{}
+    |> Registration.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a registration.
+
+  ## Examples
+
+      iex> update_registration(registration, %{field: new_value})
+      {:ok, %Registration{}}
+
+      iex> update_registration(registration, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_registration(%Registration{} = registration, attrs) do
+    registration
+    |> Registration.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Registration.
+
+  ## Examples
+
+      iex> delete_registration(registration)
+      {:ok, %Registration{}}
+
+      iex> delete_registration(registration)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_registration(%Registration{} = registration) do
+    Repo.delete(registration)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking registration changes.
+
+  ## Examples
+
+      iex> change_registration(registration)
+      %Ecto.Changeset{source: %Registration{}}
+
+  """
+  def change_registration(%Registration{} = registration) do
+    Registration.changeset(registration, %{})
+  end
 end

--- a/lib/companion/companion_web/registration.ex
+++ b/lib/companion/companion_web/registration.ex
@@ -1,0 +1,37 @@
+defmodule Companion.CompanionWeb.Registration do
+  @moduledoc """
+  Schema for Registrations
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Honeydew.EctoPollQueue.Schema
+
+  schema "registrations" do
+    field(:channel, :string)
+    field(:facility_code, :string)
+    field(:msisdn, :string)
+    field(:persal, :string)
+    field(:registered_by, :string)
+    field(:sanc, :string)
+    field(:timestamp, :utc_datetime)
+
+    timestamps()
+
+    honeydew_fields(:process_registration)
+  end
+
+  @doc false
+  def changeset(registration, attrs) do
+    registration
+    |> cast(attrs, [
+      :msisdn,
+      :registered_by,
+      :channel,
+      :facility_code,
+      :persal,
+      :sanc,
+      :timestamp
+    ])
+    |> validate_required([:msisdn, :registered_by, :channel, :facility_code, :timestamp])
+  end
+end

--- a/lib/companion_web/clients/openhim.ex
+++ b/lib/companion_web/clients/openhim.ex
@@ -10,6 +10,10 @@ defmodule CompanionWeb.Clients.OpenHIM do
     username: Application.get_env(:companion, :openhim)[:username],
     password: Application.get_env(:companion, :openhim)[:password]
 
+  plug Tesla.Middleware.Headers, [
+    {"user-agent", "nurseconnect-companion"}
+  ]
+
   plug Tesla.Middleware.JSON, engine: Poison
   plug Tesla.Middleware.Logger
 
@@ -32,5 +36,27 @@ defmodule CompanionWeb.Clients.OpenHIM do
   """
   def create_nurseconnect_optout(optout) do
     post!("ws/rest/v1/nc/optout", optout)
+  end
+
+  @doc """
+  Given the registration with the following data:
+
+  mha: integer
+  swt: integer
+  type: integer
+  cmsisdn: string, msisdn
+  dmsisdn: string, msisdn
+  rmsisdn: string, msisdn, optional
+  faccode: string, facility code
+  id: string, '{identifier}^^^{country}^{type}'
+  dob: string, date, optional
+  persal: string, optional
+  sanc: string, optional
+  encdate, string, date
+
+  Sends the optout to the OpenHIM API
+  """
+  def submit_nurseconnect_registration(registration) do
+    post!("ws/rest/v1/nc/subscription", registration)
   end
 end

--- a/lib/companion_web/controllers/registration_controller.ex
+++ b/lib/companion_web/controllers/registration_controller.ex
@@ -1,0 +1,27 @@
+defmodule CompanionWeb.RegistrationController do
+  use CompanionWeb, :controller
+
+  alias CompanionWeb.FallbackController
+
+  alias Companion.CompanionWeb
+  alias Companion.CompanionWeb.Registration
+
+  action_fallback FallbackController
+
+  def create(conn, %{}) do
+    conn = conn |> fetch_query_params()
+
+    with {:ok, %Registration{} = registration} <-
+           CompanionWeb.create_registration(conn.query_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", registration_path(conn, :show, registration))
+      |> render("show.json", registration: registration)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    registration = CompanionWeb.get_registration!(id)
+    render(conn, "show.json", registration: registration)
+  end
+end

--- a/lib/companion_web/controllers/registration_controller.ex
+++ b/lib/companion_web/controllers/registration_controller.ex
@@ -1,5 +1,6 @@
 defmodule CompanionWeb.RegistrationController do
   use CompanionWeb, :controller
+  use PhoenixSwagger
 
   alias CompanionWeb.FallbackController
 
@@ -7,6 +8,58 @@ defmodule CompanionWeb.RegistrationController do
   alias Companion.CompanionWeb.Registration
 
   action_fallback FallbackController
+
+  def swagger_definitions do
+    %{
+      RegistrationRequest:
+        swagger_schema do
+          title("RegistrationRequest")
+          description("Schema for a registration")
+
+          properties do
+            channel(:string, "Registration channel. SMS or WhatsApp")
+            facility_code(:string, "Code for facility where registration took place")
+            msisdn(:string, "MSISDN of person registered")
+            registered_by(:string, "MSISDN of person who performed the registration")
+            persal(:string, "Persal code of person registered", required: false)
+            sanc(:string, "SANC code of person registered", required: false)
+
+            timestamp(:timestamp, "UTC timestamp of when the registration occurred",
+              format: :utc_datetime
+            )
+          end
+
+          example(%{
+            channel: "WhatsApp",
+            facility_code: "123456",
+            msisdn: "+27820001001",
+            registered_by: "+27820001002",
+            timestamp: "2018-01-01T01:01:01"
+          })
+        end
+    }
+  end
+
+  swagger_path(:create) do
+    summary("Create registration")
+    description("Creates a new registration")
+    consumes("application/json")
+    produces("application/json")
+
+    parameters do
+      body(
+        :body,
+        Schema.ref(:RegistrationRequest),
+        "The details of the registration to be created"
+      )
+    end
+
+    response(
+      201,
+      "Registration created OK",
+      Schema.ref(:RegistrationRequest)
+    )
+  end
 
   def create(conn, %{}) do
     conn = conn |> fetch_query_params()

--- a/lib/companion_web/controllers/registration_controller.ex
+++ b/lib/companion_web/controllers/registration_controller.ex
@@ -24,7 +24,9 @@ defmodule CompanionWeb.RegistrationController do
             persal(:string, "Persal code of person registered", required: false)
             sanc(:string, "SANC code of person registered", required: false)
 
-            timestamp(:string, "UTC timestamp of when the registration occurred",
+            timestamp(
+              :string,
+              "UTC timestamp of when the registration occurred",
               format: :utc_datetime
             )
           end

--- a/lib/companion_web/controllers/registration_controller.ex
+++ b/lib/companion_web/controllers/registration_controller.ex
@@ -24,7 +24,7 @@ defmodule CompanionWeb.RegistrationController do
             persal(:string, "Persal code of person registered", required: false)
             sanc(:string, "SANC code of person registered", required: false)
 
-            timestamp(:timestamp, "UTC timestamp of when the registration occurred",
+            timestamp(:string, "UTC timestamp of when the registration occurred",
               format: :utc_datetime
             )
           end

--- a/lib/companion_web/jobs/process_registration.ex
+++ b/lib/companion_web/jobs/process_registration.ex
@@ -1,0 +1,72 @@
+defmodule Companion.Jobs.ProcessRegistration do
+  @moduledoc """
+  Does the processing required for registration hooks from Rapidpro.
+
+  Submits the registration to Jembi
+  """
+  import Companion.CompanionWeb
+  use Honeydew.Progress
+  alias Companion.CompanionWeb.Registration
+  alias Companion.Repo
+  alias CompanionWeb.Clients.OpenHIM
+
+  @mha_praekelt 1
+  @swt_sms 1
+  @swt_whatsapp 7
+  @type_nurse_registration 7
+
+  def supervisor_config do
+    [
+      :process_registration,
+      schema: Registration,
+      repo: Repo,
+      stale_timeout: Application.get_env(:honeydew, :timeout),
+      failure_mode:
+        {Honeydew.FailureMode.Retry,
+         [
+           times: Application.get_env(:honeydew, :retries)
+         ]},
+      success_mode: Honeydew.SuccessMode.Log
+    ]
+  end
+
+  defp swt_from_channel("WhatsApp") do
+    @swt_whatsapp
+  end
+
+  defp swt_from_channel(_) do
+    @swt_sms
+  end
+
+  defp id_from_msisdn(msisdn) do
+    "+" <> msisdn = msisdn
+    msisdn <> "^^^ZAF^TEL"
+  end
+
+  defp openhim_registration_from_registration(registration) do
+    %{
+      mha: @mha_praekelt,
+      swt: swt_from_channel(registration.channel),
+      type: @type_nurse_registration,
+      dmsisdn: registration.registered_by,
+      cmsisdn: registration.msisdn,
+      rmsisdn: nil,
+      faccode: registration.facility_code,
+      id: id_from_msisdn(registration.msisdn),
+      dob: nil,
+      persal: registration.persal,
+      sanc: registration.sanc,
+      encdate:
+        registration.timestamp
+        |> Timex.format!("{YYYY}{0M}{0D}{h24}{m}{s}")
+    }
+  end
+
+  def run(id) do
+    _ =
+      id
+      |> get_registration!()
+      |> openhim_registration_from_registration()
+      |> OpenHIM.submit_nurseconnect_registration()
+  end
+end

--- a/lib/companion_web/router.ex
+++ b/lib/companion_web/router.ex
@@ -63,6 +63,7 @@ defmodule CompanionWeb.Router do
     pipe_through [:api, :authenticated]
 
     resources "/templatemessages", TemplateMessageController, only: [:create, :show]
+    resources "/registration", RegistrationController, only: [:create, :show]
   end
 
   scope "/api/docs" do

--- a/lib/companion_web/views/registration_view.ex
+++ b/lib/companion_web/views/registration_view.ex
@@ -1,0 +1,21 @@
+defmodule CompanionWeb.RegistrationView do
+  use CompanionWeb, :view
+  alias CompanionWeb.RegistrationView
+
+  def render("show.json", %{registration: registration}) do
+    render_one(registration, RegistrationView, "registration.json")
+  end
+
+  def render("registration.json", %{registration: registration}) do
+    %{
+      id: registration.id,
+      msisdn: registration.msisdn,
+      registered_by: registration.registered_by,
+      channel: registration.channel,
+      facility_code: registration.facility_code,
+      persal: registration.persal,
+      sanc: registration.sanc,
+      timestamp: registration.timestamp
+    }
+  end
+end

--- a/priv/repo/migrations/20190604073016_create_registrations.exs
+++ b/priv/repo/migrations/20190604073016_create_registrations.exs
@@ -1,0 +1,21 @@
+defmodule Companion.Repo.Migrations.CreateRegistrations do
+  use Ecto.Migration
+  import Honeydew.EctoPollQueue.Migration
+
+  def change do
+    create table(:registrations) do
+      add(:msisdn, :string)
+      add(:registered_by, :string)
+      add(:channel, :string)
+      add(:facility_code, :string)
+      add(:persal, :string)
+      add(:sanc, :string)
+      add(:timestamp, :utc_datetime)
+
+      timestamps()
+      honeydew_fields(:process_registration)
+    end
+
+    honeydew_indexes(:registrations, :process_registration)
+  end
+end

--- a/test/companion/companion_web/companion_web_test.exs
+++ b/test/companion/companion_web/companion_web_test.exs
@@ -220,4 +220,108 @@ defmodule Companion.CompanionWebTest do
       assert %Ecto.Changeset{} = CompanionWeb.change_template_message(template_message)
     end
   end
+
+  describe "registrations" do
+    alias Companion.CompanionWeb.Registration
+
+    @valid_attrs %{
+      channel: "some channel",
+      facility_code: "some facility_code",
+      msisdn: "some msisdn",
+      persal: "some persal",
+      registered_by: "some registered_by",
+      sanc: "some sanc",
+      timestamp: "2018-01-01T01:01:01.000000"
+    }
+    @update_attrs %{
+      channel: "some updated channel",
+      facility_code: "some updated facility_code",
+      msisdn: "some updated msisdn",
+      persal: "some updated persal",
+      registered_by: "some updated registered_by",
+      sanc: "some updated sanc",
+      timestamp: "2018-01-01T01:01:01.000000"
+    }
+    @invalid_attrs %{
+      channel: nil,
+      facility_code: nil,
+      msisdn: nil,
+      persal: nil,
+      registered_by: nil,
+      sanc: nil
+    }
+
+    def registration_fixture(attrs \\ %{}) do
+      {:ok, registration} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> CompanionWeb.create_registration()
+
+      registration
+    end
+
+    test "list_registrations/0 returns all registrations" do
+      registration = registration_fixture()
+      [result] = CompanionWeb.list_registrations()
+      result = %{result | honeydew_process_registration_lock: nil}
+      assert result == registration
+    end
+
+    test "get_registration!/1 returns the registration with given id" do
+      registration = registration_fixture()
+      result = CompanionWeb.get_registration!(registration.id)
+      result = %{result | honeydew_process_registration_lock: nil}
+      assert result == registration
+    end
+
+    test "create_registration/1 with valid data creates a registration" do
+      assert {:ok, %Registration{} = registration} =
+               CompanionWeb.create_registration(@valid_attrs)
+
+      assert registration.channel == "some channel"
+      assert registration.facility_code == "some facility_code"
+      assert registration.msisdn == "some msisdn"
+      assert registration.persal == "some persal"
+      assert registration.registered_by == "some registered_by"
+      assert registration.sanc == "some sanc"
+    end
+
+    test "create_registration/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = CompanionWeb.create_registration(@invalid_attrs)
+    end
+
+    test "update_registration/2 with valid data updates the registration" do
+      registration = registration_fixture()
+      assert {:ok, registration} = CompanionWeb.update_registration(registration, @update_attrs)
+      assert %Registration{} = registration
+      assert registration.channel == "some updated channel"
+      assert registration.facility_code == "some updated facility_code"
+      assert registration.msisdn == "some updated msisdn"
+      assert registration.persal == "some updated persal"
+      assert registration.registered_by == "some updated registered_by"
+      assert registration.sanc == "some updated sanc"
+    end
+
+    test "update_registration/2 with invalid data returns error changeset" do
+      registration = registration_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               CompanionWeb.update_registration(registration, @invalid_attrs)
+
+      result = CompanionWeb.get_registration!(registration.id)
+      result = %{result | honeydew_process_registration_lock: nil}
+      assert registration == result
+    end
+
+    test "delete_registration/1 deletes the registration" do
+      registration = registration_fixture()
+      assert {:ok, %Registration{}} = CompanionWeb.delete_registration(registration)
+      assert_raise Ecto.NoResultsError, fn -> CompanionWeb.get_registration!(registration.id) end
+    end
+
+    test "change_registration/1 returns a registration changeset" do
+      registration = registration_fixture()
+      assert %Ecto.Changeset{} = CompanionWeb.change_registration(registration)
+    end
+  end
 end

--- a/test/companion_web/controllers/registration_controller_test.exs
+++ b/test/companion_web/controllers/registration_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule CompanionWeb.RegistrationControllerTest do
   use CompanionWeb.ConnCase
+  use PhoenixSwagger.SchemaTest, "priv/static/swagger.json"
 
   alias Companion.CompanionWeb.Application
 

--- a/test/companion_web/controllers/registration_controller_test.exs
+++ b/test/companion_web/controllers/registration_controller_test.exs
@@ -1,0 +1,52 @@
+defmodule CompanionWeb.RegistrationControllerTest do
+  use CompanionWeb.ConnCase
+
+  alias Companion.CompanionWeb.Application
+
+  @create_attrs %{
+    channel: "some channel",
+    facility_code: "some facility_code",
+    msisdn: "some msisdn",
+    registered_by: "some registered_by",
+    timestamp: "2018-01-01T01:01:01.000000"
+  }
+  @invalid_attrs %{channel: nil, facility_code: nil, msisdn: nil, registered_by: nil}
+  @application %Application{name: "test", token: Ecto.UUID.generate()}
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> assign(:application, @application)
+      |> put_req_header("accept", "application/json")
+
+    {:ok, %{conn: conn}}
+  end
+
+  describe "create registration" do
+    test "renders registration when data is valid", %{conn: conn} do
+      conn = post(conn, registration_path(conn, :create, Map.to_list(@create_attrs)))
+      assert %{"id" => id, "timestamp" => created} = json_response(conn, 201)
+
+      conn =
+        build_conn()
+        |> assign(:application, @application)
+        |> get(registration_path(conn, :show, id))
+
+      assert json_response(conn, 200) == %{
+               "id" => id,
+               "channel" => "some channel",
+               "facility_code" => "some facility_code",
+               "msisdn" => "some msisdn",
+               "persal" => nil,
+               "registered_by" => "some registered_by",
+               "sanc" => nil,
+               "timestamp" => created
+             }
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, registration_path(conn, :create, Map.to_list(@invalid_attrs)))
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+end

--- a/test/jobs/process_opt_out_test.exs
+++ b/test/jobs/process_opt_out_test.exs
@@ -43,7 +43,11 @@ defmodule Companion.Jobs.ProcessOptOutTests do
       %{
         method: :post,
         url: "http://openhim/ws/rest/v1/nc/optout",
-        headers: [{"authorization", "Basic dXNlcjpwYXNz"}, {"content-type", "application/json"}],
+        headers: [
+          {"authorization", "Basic dXNlcjpwYXNz"},
+          {"user-agent", "nurseconnect-companion"},
+          {"content-type", "application/json"}
+        ],
         body: @openhim_expected_request
       } ->
         %Tesla.Env{status: 202, body: "Accepted"}

--- a/test/jobs/process_registration_test.exs
+++ b/test/jobs/process_registration_test.exs
@@ -1,0 +1,73 @@
+defmodule Companion.Jobs.ProcessRegistrationTests do
+  use Companion.DataCase
+
+  import Companion.CompanionWeb
+  alias Companion.Jobs.ProcessRegistration
+  import Tesla.Mock
+
+  @registration_request %{
+    type: 7,
+    sanc: nil,
+    rmsisdn: nil,
+    persal: nil,
+    mha: 1,
+    id: "27820001001^^^ZAF^TEL",
+    faccode: "123456",
+    encdate: "20180101010101",
+    dob: nil,
+    dmsisdn: "+27820001002",
+    cmsisdn: "+27820001001"
+  }
+  @whatsapp_registration_request Poison.encode!(Map.merge(@registration_request, %{swt: 7}))
+  @sms_registration_request Poison.encode!(Map.merge(@registration_request, %{swt: 1}))
+
+  defp mock_request(response) do
+    mock(fn
+      %{
+        method: :post,
+        url: "http://openhim/ws/rest/v1/nc/subscription",
+        headers: [
+          {"authorization", "Basic dXNlcjpwYXNz"},
+          {"user-agent", "nurseconnect-companion"},
+          {"content-type", "application/json"}
+        ],
+        body: response
+      } ->
+        json(%{})
+    end)
+
+    response
+  end
+
+  test "Submits the WhatsApp registration" do
+    mock_request(@whatsapp_registration_request)
+
+    {:ok, registration} =
+      create_registration(%{
+        msisdn: "+27820001001",
+        registered_by: "+27820001002",
+        channel: "WhatsApp",
+        facility_code: "123456",
+        timestamp: "2018-01-01T01:01:01"
+      })
+
+    ProcessRegistration.run(registration.id)
+    :ok
+  end
+
+  test "Submits the SMS registration" do
+    mock_request(@sms_registration_request)
+
+    {:ok, registration} =
+      create_registration(%{
+        msisdn: "+27820001001",
+        registered_by: "+27820001002",
+        channel: "SMS",
+        facility_code: "123456",
+        timestamp: "2018-01-01T01:01:01"
+      })
+
+    ProcessRegistration.run(registration.id)
+    :ok
+  end
+end


### PR DESCRIPTION
This PR creates an API endpoint for submitting registrations from RapidPro webhooks. The registration details then get sent to OpenHIM in a background task