### PR TITLE
Send mha=6 to OpenHIM

### DIFF
--- a/lib/companion_web/jobs/process_registration.ex
+++ b/lib/companion_web/jobs/process_registration.ex
@@ -10,7 +10,7 @@ defmodule Companion.Jobs.ProcessRegistration do
   alias Companion.Repo
   alias CompanionWeb.Clients.OpenHIM
 
-  @mha_praekelt 1
+  @mha_praekelt 6 #  registration via whatsapp
   @swt_sms 1
   @swt_whatsapp 7
   @type_nurse_registration 7

--- a/lib/companion_web/jobs/process_registration.ex
+++ b/lib/companion_web/jobs/process_registration.ex
@@ -10,7 +10,8 @@ defmodule Companion.Jobs.ProcessRegistration do
   alias Companion.Repo
   alias CompanionWeb.Clients.OpenHIM
 
-  @mha_praekelt 6 #  registration via whatsapp
+  #  registration via whatsapp
+  @mha_praekelt 6
   @swt_sms 1
   @swt_whatsapp 7
   @type_nurse_registration 7

--- a/test/jobs/process_registration_test.exs
+++ b/test/jobs/process_registration_test.exs
@@ -31,7 +31,7 @@ defmodule Companion.Jobs.ProcessRegistrationTests do
           {"user-agent", "nurseconnect-companion"},
           {"content-type", "application/json"}
         ],
-        body: response
+        body: ^response
       } ->
         json(%{})
     end)

--- a/test/jobs/process_registration_test.exs
+++ b/test/jobs/process_registration_test.exs
@@ -10,7 +10,7 @@ defmodule Companion.Jobs.ProcessRegistrationTests do
     sanc: nil,
     rmsisdn: nil,
     persal: nil,
-    mha: 1,
+    mha: 6,
     id: "27820001001^^^ZAF^TEL",
     faccode: "123456",
     encdate: "20180101010101",


### PR DESCRIPTION
The mha value sent to OpenHIM for registrations via whatsapp should be 6.
My understanding is that this application only deals with registrations via whatsapp, so there is no need to provide functionality for other values at this time.

While working on this it was noted that the tests did not seem to be checking the request data correctly.
(tx @jerith)